### PR TITLE
fix(acc) Fixes hitting enter on account selector

### DIFF
--- a/internal/display/layout.go
+++ b/internal/display/layout.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rivo/tview"
 	"github.com/vitorqb/addledger/internal/accountguesser"
 	"github.com/vitorqb/addledger/internal/controller"
+	contextmod "github.com/vitorqb/addledger/internal/display/context"
 	"github.com/vitorqb/addledger/internal/eventbus"
 	"github.com/vitorqb/addledger/internal/state"
 )
@@ -29,7 +30,33 @@ func NewLayout(
 ) (*Layout, error) {
 	view := NewView(state)
 	input := NewInput(controller, state, eventBus)
-	context, err := NewContext(state, eventBus, accountGuesser)
+
+	// Creates a Context
+	accountList, err := NewAccountList(state, eventBus, accountGuesser)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create account list: %w", err)
+	}
+	descriptionPicker, err := contextmod.NewDescriptionPicker(state, eventBus)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create description picker: %w", err)
+	}
+	ammountGuesser, err := contextmod.NewAmmountGuesser(state)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ammount guesser: %w", err)
+	}
+	dateGuesser, err := NewDateGuesser(state)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create date guesser: %w", err)
+	}
+	contextWidgets := []ContextWidget{
+		{PageName: "accountList", Widget: accountList},
+		{PageName: "descriptionPicker", Widget: descriptionPicker},
+		{PageName: "ammountGuesser", Widget: ammountGuesser},
+		{PageName: "dateGuesser", Widget: dateGuesser},
+		{PageName: "empty", Widget: tview.NewBox()},
+	}
+
+	context, err := NewContext(state, contextWidgets)
 	if err != nil {
 		return nil, fmt.Errorf("failed to instatiate context: %w", err)
 	}

--- a/internal/display/widgets/contextuallist.go
+++ b/internal/display/widgets/contextuallist.go
@@ -65,7 +65,7 @@ func NewContextualList(options ContextualListOptions) (*ContextualList, error) {
 	}
 	list.ShowSecondaryText(false)
 	list.SetChangedFunc(func(_ int, mainText, _ string, _ rune) {
-		logrus.WithField("text", mainText).Debug("AccountList changed")
+		logrus.WithField("text", mainText).Debug("ContextualList changed")
 		list.setSelectedFunc(mainText)
 	})
 	if list.getDefaultFunc != nil {
@@ -113,6 +113,15 @@ func (cl *ContextualList) Refresh() {
 	defer func() {
 		if cl.GetItemCount() == 0 {
 			cl.setSelectedFunc("")
+		}
+	}()
+
+	// Ensure that after we refresh the state is up-to-date with
+	// the selected item
+	defer func() {
+		if cl.GetItemCount() > 0 {
+			text, _ := cl.GetItemText(cl.GetCurrentItem())
+			cl.setSelectedFunc(text)
 		}
 	}()
 

--- a/internal/display/widgets/contextuallist_test.go
+++ b/internal/display/widgets/contextuallist_test.go
@@ -139,6 +139,18 @@ func TestContextualList(t *testing.T) {
 				assert.Equal(t, "FOO", firstItem)
 			},
 		},
+		{
+			name: "Sets selected item on Refresh",
+			run: func(t *testing.T, c *testcontext) {
+				c.selected = ""
+				c.contextualList.Refresh()
+				assert.Equal(t, "TWO", c.selected)
+				// Note: run again because of cache
+				c.selected = ""
+				c.contextualList.Refresh()
+				assert.Equal(t, "TWO", c.selected)
+			},
+		},
 	}
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes a bug where hitting "enter" on the account selector without
modifying the account would not work.
