### PR TITLE
fix: Links date guessing to state

### DIFF
--- a/cmd/addledger/main.go
+++ b/cmd/addledger/main.go
@@ -64,6 +64,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to load date guesser")
 	}
+	app.LinkDateGuesser(state, dateGuesser)
 
 	// Starts a Printer
 	printer, printerErr := injector.Printer(config.PrinterConfig)

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -122,27 +122,14 @@ func NewController(state *statemod.State, options ...Opt) (*InputController, err
 }
 
 func (ic *InputController) OnDateChanged(x string) {
-	// No input and loaded statement - use statement date
-	if x == "" {
-		if sEntry, found := ic.state.CurrentStatementEntry(); found {
-			ic.state.InputMetadata.SetDateGuess(sEntry.Date)
-			return
-		}
-	}
-
-	// Delegate to DateGuesser
-	date, success := ic.dateGuesser.Guess(x)
-	if success {
-		ic.state.InputMetadata.SetDateGuess(date)
-	} else {
-		ic.state.InputMetadata.ClearDateGuess()
-	}
+	ic.state.InputMetadata.SetDateText(x)
 }
 
 func (ic *InputController) OnDateDone() {
 	if date, found := ic.state.InputMetadata.GetDateGuess(); found {
 		ic.state.Transaction.Date.Set(date)
 		ic.state.NextPhase()
+		return
 	}
 }
 

--- a/internal/dateguesser/dateguesser_test.go
+++ b/internal/dateguesser/dateguesser_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	. "github.com/vitorqb/addledger/internal/dateguesser"
+	"github.com/vitorqb/addledger/internal/finance"
 	"github.com/vitorqb/addledger/internal/testutils"
 	. "github.com/vitorqb/addledger/mocks/dateguesser"
 )
@@ -24,16 +25,25 @@ func TestDateGuesser(t *testing.T) {
 			name: "No input suggests today",
 			run: func(c *testcontext, t *testing.T) {
 				c.clock.EXPECT().Now().Return(testutils.Date1(t))
-				guess, success := c.guesser.Guess("")
+				guess, success := c.guesser.Guess("", finance.StatementEntry{})
 				assert.True(t, success)
 				assert.Equal(t, testutils.Date1(t), guess)
+			},
+		},
+		{
+			name: "No input with statement entry suggests statement entry",
+			run: func(c *testcontext, t *testing.T) {
+				c.clock.EXPECT().Now().AnyTimes().Return(testutils.Date1(t))
+				guess, success := c.guesser.Guess("", finance.StatementEntry{Date: testutils.Date2(t)})
+				assert.True(t, success)
+				assert.Equal(t, testutils.Date2(t), guess)
 			},
 		},
 		{
 			name: "Valid user input (full date)",
 			run: func(c *testcontext, t *testing.T) {
 				c.clock.EXPECT().Now().Return(testutils.Date1(t))
-				guess, success := c.guesser.Guess("1993-11-23")
+				guess, success := c.guesser.Guess("1993-11-23", finance.StatementEntry{})
 				assert.True(t, success)
 				assert.Equal(t, testutils.Date1(t), guess)
 			},
@@ -42,7 +52,7 @@ func TestDateGuesser(t *testing.T) {
 			name: "Valid user input (day only)",
 			run: func(c *testcontext, t *testing.T) {
 				c.clock.EXPECT().Now().Return(testutils.Date1(t))
-				guess, success := c.guesser.Guess("23")
+				guess, success := c.guesser.Guess("23", finance.StatementEntry{})
 				assert.True(t, success)
 				assert.Equal(t, testutils.Date1(t), guess)
 			},
@@ -51,7 +61,7 @@ func TestDateGuesser(t *testing.T) {
 			name: "Valid user input (day only, 1 digit month)",
 			run: func(c *testcontext, t *testing.T) {
 				c.clock.EXPECT().Now().AnyTimes().Return(testutils.Date2(t))
-				guess, success := c.guesser.Guess("01")
+				guess, success := c.guesser.Guess("01", finance.StatementEntry{})
 				assert.True(t, success)
 				assert.Equal(t, testutils.Date2(t), guess)
 			},
@@ -60,7 +70,7 @@ func TestDateGuesser(t *testing.T) {
 			name: "Valid user input (month and day)",
 			run: func(c *testcontext, t *testing.T) {
 				c.clock.EXPECT().Now().Return(testutils.Date1(t))
-				guess, success := c.guesser.Guess("11-23")
+				guess, success := c.guesser.Guess("11-23", finance.StatementEntry{})
 				assert.True(t, success)
 				assert.Equal(t, testutils.Date1(t), guess)
 			},
@@ -69,7 +79,7 @@ func TestDateGuesser(t *testing.T) {
 			name: "Previous day",
 			run: func(c *testcontext, t *testing.T) {
 				c.clock.EXPECT().Now().Return(testutils.Date1(t))
-				guess, success := c.guesser.Guess("-1")
+				guess, success := c.guesser.Guess("-1", finance.StatementEntry{})
 				assert.True(t, success)
 				assert.Equal(t, testutils.Date1(t).AddDate(0, 0, -1), guess)
 			},
@@ -78,7 +88,7 @@ func TestDateGuesser(t *testing.T) {
 			name: "Two days ago",
 			run: func(c *testcontext, t *testing.T) {
 				c.clock.EXPECT().Now().Return(testutils.Date1(t))
-				guess, success := c.guesser.Guess("-2")
+				guess, success := c.guesser.Guess("-2", finance.StatementEntry{})
 				assert.True(t, success)
 				assert.Equal(t, testutils.Date1(t).AddDate(0, 0, -2), guess)
 			},
@@ -87,7 +97,7 @@ func TestDateGuesser(t *testing.T) {
 			name: "Invalid user input",
 			run: func(c *testcontext, t *testing.T) {
 				c.clock.EXPECT().Now().Return(testutils.Date1(t))
-				_, success := c.guesser.Guess("41")
+				_, success := c.guesser.Guess("41", finance.StatementEntry{})
 				assert.False(t, success)
 			},
 		},

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -43,6 +43,7 @@ type (
 
 		// Controls date
 		dateGuess *MaybeValue[time.Time]
+		dateText  string
 
 		// The transactions that match the current input
 		matchingTransactions []journal.Transaction
@@ -174,6 +175,7 @@ func InitialState() *State {
 		postingAmmountInput:    &MaybeValue[finance.Ammount]{},
 		postingAmmountText:     "",
 		dateGuess:              &MaybeValue[time.Time]{},
+		dateText:               "",
 		matchingTransactions:   []journal.Transaction{},
 	}
 	journalMetadata := NewJournalMetadata()
@@ -364,6 +366,17 @@ func (im *InputMetadata) SetDateGuess(x time.Time) {
 // ClearDateGuess clears the current date guess
 func (im *InputMetadata) ClearDateGuess() {
 	im.dateGuess.Clear()
+	im.NotifyChange()
+}
+
+// GetDateText returns the current text for the date input
+func (im *InputMetadata) GetDateText() string {
+	return im.dateText
+}
+
+// SetDateText sets the current text for the date input
+func (im *InputMetadata) SetDateText(x string) {
+	im.dateText = x
 	im.NotifyChange()
 }
 

--- a/mocks/dateguesser/dateguesser_mock.go
+++ b/mocks/dateguesser/dateguesser_mock.go
@@ -9,6 +9,7 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
+	finance "github.com/vitorqb/addledger/internal/finance"
 )
 
 // MockIClock is a mock of IClock interface.
@@ -72,16 +73,16 @@ func (m *MockIDateGuesser) EXPECT() *MockIDateGuesserMockRecorder {
 }
 
 // Guess mocks base method.
-func (m *MockIDateGuesser) Guess(userInput string) (time.Time, bool) {
+func (m *MockIDateGuesser) Guess(userInput string, statementEntry finance.StatementEntry) (time.Time, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Guess", userInput)
+	ret := m.ctrl.Call(m, "Guess", userInput, statementEntry)
 	ret0, _ := ret[0].(time.Time)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
 // Guess indicates an expected call of Guess.
-func (mr *MockIDateGuesserMockRecorder) Guess(userInput interface{}) *gomock.Call {
+func (mr *MockIDateGuesserMockRecorder) Guess(userInput, statementEntry interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Guess", reflect.TypeOf((*MockIDateGuesser)(nil).Guess), userInput)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Guess", reflect.TypeOf((*MockIDateGuesser)(nil).Guess), userInput, statementEntry)
 }


### PR DESCRIPTION
fixes #81

Instead of calculating the guess on the controller, which caused the
guess to be out-date with state data, calculates the guess on every
state change using app.LinkDateGuesser
