### PR TITLE
fix: properly set tags when creating final Transaction

### DIFF
--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -83,4 +83,33 @@ func TestPrinter_Print(t *testing.T) {
 		0,
 		"1993-11-23 Description1  ; trip:brazil\n    ACC1    EUR 12.2\n    ACC2    EUR -12.2",
 	)
+
+	withTagsTransaction := *tu.Transaction_1(t)
+	withTagsTransaction.Tags = []journal.Tag{
+		{Name: "tag1", Value: "value1"},
+		{Name: "tag2", Value: "value2"},
+	}
+	RunTest(
+		t,
+		"With tags",
+		withTagsTransaction,
+		0,
+		0,
+		"1993-11-23 Description1  ; tag1:value1 tag2:value2\n    ACC1    EUR 12.2\n    ACC2    EUR -12.2",
+	)
+
+	withCommentAndTagsTransaction := *tu.Transaction_1(t)
+	withCommentAndTagsTransaction.Comment = "Foo!"
+	withCommentAndTagsTransaction.Tags = []journal.Tag{
+		{Name: "tag1", Value: "value1"},
+		{Name: "tag2", Value: "value2"},
+	}
+	RunTest(
+		t,
+		"With comment and tags",
+		withCommentAndTagsTransaction,
+		0,
+		0,
+		"1993-11-23 Description1  ; Foo! tag1:value1 tag2:value2\n    ACC1    EUR 12.2\n    ACC2    EUR -12.2",
+	)
 }

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -98,6 +98,7 @@ func Transaction_1(t *testing.T) *journal.Transaction {
 				},
 			},
 		},
+		Tags: []journal.Tag{},
 	}
 }
 

--- a/internal/userinput/userinput.go
+++ b/internal/userinput/userinput.go
@@ -115,18 +115,10 @@ func TransactionFromData(t *state.TransactionData) (journal.Transaction, error) 
 		return journal.Transaction{}, fmt.Errorf("missing date")
 	}
 
-	comment := ""
-	for i, tag := range t.Tags.Get() {
-		if i != 0 {
-			comment += " "
-		}
-		comment += TagToText(tag)
-	}
-
 	return journal.Transaction{
 		Description: description,
 		Date:        date,
-		Comment:     comment,
+		Tags:        t.Tags.Get(),
 		Posting:     postings,
 	}, nil
 }

--- a/internal/userinput/userinput_test.go
+++ b/internal/userinput/userinput_test.go
@@ -127,7 +127,7 @@ func TestTransactionFromData(t *testing.T) {
 			},
 			expectedTransaction: func(t *testing.T) *journal.Transaction {
 				out := tu.Transaction_1(t)
-				out.Comment = "foo:bar"
+				out.Tags = []journal.Tag{{Name: "foo", Value: "bar"}}
 				return out
 			},
 		},


### PR DESCRIPTION
When creating the final Transaction on the
`userinput.TransactionFromData` we were not passing the `Tags` along,
but instead saving it as `Comment`. This worked well for printing but
it also meant that the transaction we were saving into the state did
not have Tags. This was causing a missbehavior of the tags input,
which would not have the tag of the latest transaction.

This commit:

1. Properly handle `Tags` on TransactionFromData
2. Properly handle `Tags` on the printer
