### PR TITLE
chore(shortcutmodal): cleanup old method

### DIFF
--- a/internal/display/shortcutmodal.go
+++ b/internal/display/shortcutmodal.go
@@ -11,12 +11,6 @@ import (
 
 type ShortcutModalController interface {
 	OnHideShortcutModal()
-	// !!!! TODO DELETE
-	// Aciton to discard the current loaded statement.
-	OnPopStatement()
-	// !!!! TODO DELETE
-	// Action to load a new statement.
-	OnLoadStatementRequest()
 	// Displays the statement modal
 	OnShowStatementModal()
 }
@@ -29,8 +23,6 @@ type ShortcutModal struct {
 func getBodyText() string {
 	return strings.Trim(
 		"s - Statement modal\n"+
-			"d - Discard statement\n"+
-			"l - Load statement\n"+
 			"q - Quit\n",
 		"\n",
 	)
@@ -48,14 +40,6 @@ func NewShortcutModal(controller ShortcutModalController) *ShortcutModal {
 			case 's':
 				modal.controller.OnShowStatementModal()
 				modal.controller.OnHideShortcutModal()
-			case 'l':
-				modal.controller.OnLoadStatementRequest()
-				modal.controller.OnHideShortcutModal()
-				return nil
-			case 'd':
-				modal.controller.OnPopStatement()
-				modal.controller.OnHideShortcutModal()
-				return nil
 			case 'q':
 				modal.controller.OnHideShortcutModal()
 				return nil

--- a/internal/display/shortcutmodal_test.go
+++ b/internal/display/shortcutmodal_test.go
@@ -45,20 +45,6 @@ func TestShortcutModal(t *testing.T) {
 			}),
 		},
 		{
-			name: "Calls discard statement on d",
-			run: testExpectOnKey(tcell.KeyRune, 'd', tcell.ModNone, func(c *MockShortcutModalController) {
-				c.EXPECT().OnPopStatement().Times(1)
-				c.EXPECT().OnHideShortcutModal().Times(1)
-			}),
-		},
-		{
-			name: "Calls load statement on l",
-			run: testExpectOnKey(tcell.KeyRune, 'l', tcell.ModNone, func(c *MockShortcutModalController) {
-				c.EXPECT().OnLoadStatementRequest().Times(1)
-				c.EXPECT().OnHideShortcutModal().Times(1)
-			}),
-		},
-		{
 			name: "Calls show statement modal",
 			run: testExpectOnKey(tcell.KeyRune, 's', tcell.ModNone, func(c *MockShortcutModalController) {
 				c.EXPECT().OnShowStatementModal().Times(1)

--- a/mocks/display/shortcutmodal_mock.go
+++ b/mocks/display/shortcutmodal_mock.go
@@ -45,30 +45,6 @@ func (mr *MockShortcutModalControllerMockRecorder) OnHideShortcutModal() *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnHideShortcutModal", reflect.TypeOf((*MockShortcutModalController)(nil).OnHideShortcutModal))
 }
 
-// OnLoadStatementRequest mocks base method.
-func (m *MockShortcutModalController) OnLoadStatementRequest() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "OnLoadStatementRequest")
-}
-
-// OnLoadStatementRequest indicates an expected call of OnLoadStatementRequest.
-func (mr *MockShortcutModalControllerMockRecorder) OnLoadStatementRequest() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnLoadStatementRequest", reflect.TypeOf((*MockShortcutModalController)(nil).OnLoadStatementRequest))
-}
-
-// OnPopStatement mocks base method.
-func (m *MockShortcutModalController) OnPopStatement() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "OnPopStatement")
-}
-
-// OnPopStatement indicates an expected call of OnPopStatement.
-func (mr *MockShortcutModalControllerMockRecorder) OnPopStatement() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnPopStatement", reflect.TypeOf((*MockShortcutModalController)(nil).OnPopStatement))
-}
-
 // OnShowStatementModal mocks base method.
 func (m *MockShortcutModalController) OnShowStatementModal() {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
We can now use the statement modal to control statements
